### PR TITLE
Use migration tree instead of sorted migrations.

### DIFF
--- a/django_migrations_ci/management/commands/migrateci.py
+++ b/django_migrations_ci/management/commands/migrateci.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
 
         suffix = ""
         if local:
-            suffix = f"-{django.hash_files()}"
+            suffix = f"-{next(django.hash_files())}"
 
         storage = storage_class(directory)
 

--- a/django_migrations_ci/tests/test_django.py
+++ b/django_migrations_ci/tests/test_django.py
@@ -1,5 +1,6 @@
 import pytest
 
+import django as djangoframework
 from django_migrations_ci import django
 
 
@@ -32,3 +33,12 @@ def test_fix_sqlite_pytest_suffix(db_name, expected_db_name):
 )
 def test_transform_sqlite_name(db_name, expected_db_name):
     assert django._transform_sqlite_db_name(db_name) == expected_db_name
+
+
+def test_hash_files():
+    djangoframework.setup()
+    it = django.hash_files()
+    assert next(it) == "d41d8cd98f00b204e9800998ecf8427e"
+    assert next(it) == "e7cc3570aebddf921af899fc45ba3e9c"
+    with pytest.raises(StopIteration):
+        next(it)

--- a/django_migrations_ci/tests/test_migrateci_command.py
+++ b/django_migrations_ci/tests/test_migrateci_command.py
@@ -71,7 +71,7 @@ def test_migrateci_cached(mocker):
 def test_migrateci_local():
     execute_from_command_line(["manage.py", "migrateci", "--local"])
     _check_db(connections["default"])
-    checksum = "b2bed1815363a843fdc8403d36497ddd"
+    checksum = "d41d8cd98f00b204e9800998ecf8427e"
     assert Path(f"migrateci-default-{checksum}").exists()
 
 


### PR DESCRIPTION
It is better because I can trust only migrations without looking for other files, like requirements.txt to check if third party dependencies added migrations.